### PR TITLE
CLOUD-705: support read-config k9 access capability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ kitchen:
 docs:
 	$(call terraform-docs,markdown . > interface.md)
 	$(call terraform-docs,markdown ./k9policy > k9policy/interface.md)
+	@awk '{sub("139710491120","12345678910")}1' test/fixtures/minimal/generated/declarative_privilege_policy.json	> examples/generated.least_privilege_policy.json
 
 all: deps init format converge verify docs
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ locals {
     , "arn:aws:iam::12345678910:user/person1"
   ]
 
-  read_config_arns = local.administrator_arns
+  read_config_arns = concat(local.administrator_arns, ["arn:aws:iam::12345678910:role/k9-auditor"])
 
   read_data_arns = [
     "arn:aws:iam::12345678910:user/person1",

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ writing a least privilege access policy directly in terms of API actions like `k
 who should be able to `read-data`.  This module supports the following access capabilities:
 
 * `administer-resource`
+* `read-config`
 * `read-data`
 * `write-data`
 * `delete-data`   
@@ -53,6 +54,8 @@ locals {
     "arn:aws:iam::12345678910:user/ci"
     , "arn:aws:iam::12345678910:user/person1"
   ]
+
+  read_config_arns = local.administrator_arns
 
   read_data_arns = [
     "arn:aws:iam::12345678910:user/person1",
@@ -77,6 +80,7 @@ module "encryption_key" {
   app   = "someapi"
 
   allow_administer_resource_arns = local.administrator_arns
+  allow_read_config_arns         = local.read_config_arns
   allow_read_data_arns           = local.read_data_arns
   allow_write_data_arns          = local.write_data_arns
 }
@@ -121,6 +125,7 @@ module "least_privilege_key_resource_policy" {
   kms_key_arn   = module.encryption_key.key_arn
 
   allow_administer_resource_arns = local.administrator_arns
+  allow_read_config_arns         = local.read_config_arns
   allow_read_data_arns           = local.read_data_arns
   allow_write_data_arns          = local.write_data_arns
 }

--- a/examples/generated.least_privilege_policy.json
+++ b/examples/generated.least_privilege_policy.json
@@ -14,7 +14,9 @@
       "Sid": "AllowRestrictedAdministerResource",
       "Effect": "Allow",
       "Action": [
+        "kms:UpdateKeyDescription",
         "kms:UpdateCustomKeyStore",
+        "kms:UpdateAlias",
         "kms:UntagResource",
         "kms:TagResource",
         "kms:ScheduleKeyDeletion",
@@ -48,10 +50,9 @@
       }
     },
     {
-      "Sid": "AllowRestrictedReadData",
+      "Sid": "AllowRestrictedReadConfig",
       "Effect": "Allow",
       "Action": [
-        "kms:Verify",
         "kms:ListRetirableGrants",
         "kms:ListResourceTags",
         "kms:ListKeys",
@@ -63,7 +64,27 @@
         "kms:GetKeyRotationStatus",
         "kms:GetKeyPolicy",
         "kms:DescribeKey",
-        "kms:DescribeCustomKeyStores",
+        "kms:DescribeCustomKeyStores"
+      ],
+      "Resource": "*",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Condition": {
+        "ArnEquals": {
+          "aws:PrincipalArn": [
+            "arn:aws:iam::12345678910:user/person1",
+            "arn:aws:iam::12345678910:user/ci",
+            "arn:aws:iam::12345678910:role/k9-auditor"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "AllowRestrictedReadData",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Verify",
         "kms:Decrypt"
       ],
       "Resource": "*",
@@ -83,8 +104,6 @@
       "Sid": "AllowRestrictedWriteData",
       "Effect": "Allow",
       "Action": [
-        "kms:UpdateKeyDescription",
-        "kms:UpdateAlias",
         "kms:Sign",
         "kms:ReEncryptTo",
         "kms:ReEncryptFrom",

--- a/interface.md
+++ b/interface.md
@@ -19,6 +19,8 @@
 | allow\_administer\_resource\_test | The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike' | `string` | `"ArnEquals"` | no |
 | allow\_delete\_data\_arns | The list of fully-qualified AWS IAM ARNs authorized to delete data protected by this key. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-\* | `list(string)` | `[]` | no |
 | allow\_delete\_data\_test | The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike' | `string` | `"ArnEquals"` | no |
+| allow\_read\_config\_arns | The list of fully-qualified AWS IAM ARNs authorized to read configuration of this key. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-\* | `list(string)` | `[]` | no |
+| allow\_read\_config\_test | The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike' | `string` | `"ArnEquals"` | no |
 | allow\_read\_data\_arns | The list of fully-qualified AWS IAM ARNs authorized to read data protected by this key. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-\* | `list(string)` | `[]` | no |
 | allow\_read\_data\_test | The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike' | `string` | `"ArnEquals"` | no |
 | allow\_write\_data\_arns | The list of fully-qualified AWS IAM ARNs authorized to write data protected by this key. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-\* | `list(string)` | `[]` | no |

--- a/interface.tf
+++ b/interface.tf
@@ -119,6 +119,18 @@ variable "allow_administer_resource_test" {
   description = "The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike'"
 }
 
+variable "allow_read_config_arns" {
+  type        = list(string)
+  default     = []
+  description = "The list of fully-qualified AWS IAM ARNs authorized to read configuration of this key. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-*"
+}
+
+variable "allow_read_config_test" {
+  type        = string
+  default     = "ArnEquals"
+  description = "The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike'"
+}
+
 variable "allow_read_data_arns" {
   type        = list(string)
   default     = []

--- a/k9policy/generate-capability-lists.sh
+++ b/k9policy/generate-capability-lists.sh
@@ -3,7 +3,7 @@
 filename=$1
 echo "generating access capability lists from ${filename}"
 
-access_capabilities='administer-resource use-resource read-data write-data delete-data'
+access_capabilities='administer-resource read-config use-resource read-data write-data delete-data'
 
 for access_capability in ${access_capabilities};
 do

--- a/k9policy/interface.md
+++ b/k9policy/interface.md
@@ -21,6 +21,8 @@
 | allow\_custom\_arns\_test | The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike' | `string` | `"ArnEquals"` | no |
 | allow\_delete\_data\_arns | The list of fully-qualified AWS IAM ARNs authorized to delete data in this bucket. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-\* | `list(string)` | `[]` | no |
 | allow\_delete\_data\_test | The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike' | `string` | `"ArnEquals"` | no |
+| allow\_read\_config\_arns | The list of fully-qualified AWS IAM ARNs authorized to read configuration of this key. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-\* | `list(string)` | `[]` | no |
+| allow\_read\_config\_test | The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike' | `string` | `"ArnEquals"` | no |
 | allow\_read\_data\_arns | The list of fully-qualified AWS IAM ARNs authorized to read data in this bucket. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-\* | `list(string)` | `[]` | no |
 | allow\_read\_data\_test | The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike' | `string` | `"ArnEquals"` | no |
 | allow\_write\_data\_arns | The list of fully-qualified AWS IAM ARNs authorized to write data in this bucket. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-\* | `list(string)` | `[]` | no |

--- a/k9policy/interface.tf
+++ b/k9policy/interface.tf
@@ -10,6 +10,18 @@ variable "allow_administer_resource_test" {
   description = "The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike'"
 }
 
+variable "allow_read_config_arns" {
+  type        = list(string)
+  default     = []
+  description = "The list of fully-qualified AWS IAM ARNs authorized to read configuration of this key. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-*"
+}
+
+variable "allow_read_config_test" {
+  type        = string
+  default     = "ArnEquals"
+  description = "The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike'"
+}
+
 variable "allow_read_data_arns" {
   type        = list(string)
   default     = []

--- a/k9policy/k9-access_capability.administer-resource.tsv
+++ b/k9policy/k9-access_capability.administer-resource.tsv
@@ -1,13 +1,13 @@
-kms:CreateAlias
-kms:CreateKey
 kms:CancelKeyDeletion
 kms:ConnectCustomKeyStore
+kms:CreateAlias
 kms:CreateCustomKeyStore
 kms:CreateGrant
+kms:CreateKey
 kms:DeleteAlias
-kms:DisconnectCustomKeyStore
 kms:DisableKey
 kms:DisableKeyRotation
+kms:DisconnectCustomKeyStore
 kms:EnableKey
 kms:EnableKeyRotation
 kms:PutKeyPolicy
@@ -16,4 +16,6 @@ kms:RevokeGrant
 kms:ScheduleKeyDeletion
 kms:TagResource
 kms:UntagResource
+kms:UpdateAlias
 kms:UpdateCustomKeyStore
+kms:UpdateKeyDescription

--- a/k9policy/k9-access_capability.read-config.tsv
+++ b/k9policy/k9-access_capability.read-config.tsv
@@ -1,0 +1,12 @@
+kms:DescribeCustomKeyStores
+kms:DescribeKey
+kms:GetKeyPolicy
+kms:GetKeyRotationStatus
+kms:GetParametersForImport
+kms:GetPublicKey
+kms:ListAliases
+kms:ListGrants
+kms:ListKeyPolicies
+kms:ListKeys
+kms:ListResourceTags
+kms:ListRetirableGrants

--- a/k9policy/k9-access_capability.read-data.tsv
+++ b/k9policy/k9-access_capability.read-data.tsv
@@ -1,14 +1,2 @@
-kms:DescribeCustomKeyStores
-kms:DescribeKey
 kms:Decrypt
-kms:GetKeyPolicy
-kms:GetKeyRotationStatus
-kms:GetParametersForImport
-kms:GetPublicKey
-kms:ListAliases
-kms:ListGrants
-kms:ListKeyPolicies
-kms:ListKeys
-kms:ListResourceTags
-kms:ListRetirableGrants
 kms:Verify

--- a/k9policy/k9-access_capability.write-data.tsv
+++ b/k9policy/k9-access_capability.write-data.tsv
@@ -8,5 +8,3 @@ kms:ImportKeyMaterial
 kms:ReEncryptFrom
 kms:ReEncryptTo
 kms:Sign
-kms:UpdateAlias
-kms:UpdateKeyDescription

--- a/k9policy/policy.tf
+++ b/k9policy/policy.tf
@@ -6,6 +6,7 @@ locals {
     var.allow_custom_arns_test,
     var.allow_delete_data_test,
     var.allow_read_data_test,
+    var.allow_read_config_test,
     var.allow_write_data_test,
   ]
   like_used_in_test_condition = contains(local.tests_used_in_statements, "ArnLike")
@@ -19,6 +20,16 @@ locals {
           file(
             "${path.module}/k9-access_capability.administer-resource.tsv",
           ),
+        ),
+      ),
+    ),
+  )
+  actions_read_config = sort(
+    distinct(
+      compact(
+        split(
+          "\n",
+          file("${path.module}/k9-access_capability.read-config.tsv"),
         ),
       ),
     ),
@@ -93,6 +104,25 @@ data "aws_iam_policy_document" "resource_policy" {
     }
   }
 
+  statement {
+    sid = "AllowRestrictedReadConfig"
+
+    actions = local.actions_read_config
+
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = var.allow_read_config_test
+      values   = var.allow_read_config_arns
+      variable = "aws:PrincipalArn"
+    }
+  }
+  
   statement {
     sid = "AllowRestrictedReadData"
 

--- a/kms.tf
+++ b/kms.tf
@@ -40,6 +40,9 @@ module "resource_policy" {
   allow_administer_resource_arns = var.allow_administer_resource_arns
   allow_administer_resource_test = var.allow_administer_resource_test
 
+  allow_read_config_arns = var.allow_read_config_arns
+  allow_read_config_test = var.allow_read_config_test
+
   allow_read_data_arns = var.allow_read_data_arns
   allow_read_data_test = var.allow_read_data_test
 

--- a/test/fixtures/minimal/minimal.tf
+++ b/test/fixtures/minimal/minimal.tf
@@ -39,6 +39,7 @@ module "it_minimal" {
   app   = var.app
 
   allow_administer_resource_arns = local.administrator_arns
+  allow_read_config_arns         = local.read_config_arns
   allow_read_data_arns           = local.read_data_arns
   allow_write_data_arns          = local.write_data_arns
   # unused: allow_delete_data_arns          = [] (default)

--- a/test/fixtures/minimal/minimal.tf
+++ b/test/fixtures/minimal/minimal.tf
@@ -16,6 +16,8 @@ locals {
     "arn:aws:sts::139710491120:federated-user/skuenzli",
   ]
 
+  read_config_arns = concat(local.administrator_arns, ["arn:aws:iam::139710491120:role/k9-auditor"])
+
   write_data_arns = [
       "arn:aws:iam::139710491120:user/skuenzli",
     ]
@@ -57,6 +59,8 @@ locals {
     "arn:aws:iam::12345678910:user/person1",
   ]
 
+  example_read_config_arns = local.administrator_arns
+
   example_read_data_arns = [
     "arn:aws:iam::12345678910:user/person1",
     "arn:aws:iam::12345678910:role/appA",
@@ -69,6 +73,7 @@ module "declarative_privilege_policy" {
   source = "../../../k9policy"
 
   allow_administer_resource_arns = local.example_administrator_arns
+  allow_read_config_arns         = local.example_read_config_arns
   allow_read_data_arns           = local.example_read_data_arns
   allow_write_data_arns          = local.example_write_data_arns
   # unused: allow_delete_data_arns          = [] (default)

--- a/test/fixtures/minimal/minimal.tf
+++ b/test/fixtures/minimal/minimal.tf
@@ -60,7 +60,7 @@ locals {
     "arn:aws:iam::12345678910:user/person1",
   ]
 
-  example_read_config_arns = local.administrator_arns
+  example_read_config_arns = concat(local.example_administrator_arns, ["arn:aws:iam::12345678910:role/k9-auditor"])
 
   example_read_data_arns = [
     "arn:aws:iam::12345678910:user/person1",


### PR DESCRIPTION
Add `read-config` k9 access capability

* `read-config` is documented at https://k9security.io/docs/k9-access-capability-model/
* reclassify many read-data and some administer-resource actions to read-config
* reclassify a couple write-data actions to administer-resource
* update tests & examples