### PR TITLE
Simplify access control by removing root user's administration capabilities

### DIFF
--- a/k9policy/interface.tf
+++ b/k9policy/interface.tf
@@ -2,6 +2,11 @@ variable "allow_administer_resource_arns" {
   type        = list(string)
   default     = []
   description = "The list of fully-qualified AWS IAM ARNs authorized to administer this bucket. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-*"
+
+  validation {
+    condition     = length(var.allow_administer_resource_arns) > 0
+    error_message = "A key administrator is required, but none were specified."
+  }
 }
 
 variable "allow_administer_resource_test" {

--- a/k9policy/policy.tf
+++ b/k9policy/policy.tf
@@ -70,23 +70,8 @@ locals {
 }
 
 data "aws_iam_policy_document" "resource_policy" {
-  statement {
-    # Ensure account's root user retains access to key
-    # even if access is removed for all other principals or those principals are removed
-    sid = "AllowRootUserToAdministerKey"
-
-    effect = "Allow"
-    
-    actions = ["kms:*"]
-
-    principals {
-      type = "AWS"
-      identifiers = [local.account_root_user_arn]
-    }
-
-    resources = ["*"]
-  }
-
+  version = "2012-10-17"
+  
   statement {
     sid = "AllowRestrictedAdministerResource"
 
@@ -201,44 +186,4 @@ data "aws_iam_policy_document" "resource_policy" {
     }
   }
 
-  statement {
-    sid = "DenyEveryoneElse"
-
-    effect = "Deny"
-
-    actions = ["kms:*"]
-
-    resources = ["*"]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    condition {
-      test = local.like_used_in_test_condition ? "ArnNotLike" : "ArnNotEquals"
-      values = distinct(
-        concat(
-          [local.account_root_user_arn],
-          var.allow_administer_resource_arns,
-          var.allow_read_config_arns,
-          var.allow_read_data_arns,
-          var.allow_write_data_arns,
-          var.allow_delete_data_arns,
-          var.allow_custom_actions_arns,
-        ),
-      )
-      variable = "aws:PrincipalArn"
-    }
-    condition {
-      test = "Bool"
-      values = ["false"]
-      variable = "aws:PrincipalIsAWSService"
-    }
-    condition {
-      test = "Bool"
-      values = ["false"]
-      variable = "kms:GrantIsForAWSResource"
-    }
-  }
 }

--- a/k9policy/versions.tf
+++ b/k9policy/versions.tf
@@ -1,4 +1,4 @@
-
 terraform {
   required_version = ">= 0.12"
+  experiments      = [variable_validation]
 }


### PR DESCRIPTION
Allowing an account's root user access to a key does two things:

1. enables the root user to use the permissions granted
2. enables Identity policies attached to principals in the account to grant principals those same permissions

Denying access to a key by unintended principals via a `DenyEveryoneElse` statement is unreliable due to the need to exclude root from the Deny so that encryption operations by data services like DynamoDB still work.

But granting access to a key solely via the key policy gets people to the intended access quickly and clearly.

We implemented that path with k9-cdk last summer and it's working well.

So adopt that here.

If users need it, we can allow `read-config` operations for root and restore the `DenyEveryoneElse`. This could be useful for root in some cases, but scopes unintended access pretty narrowly.